### PR TITLE
feat(collection): add status filter for collection view

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A terminal user interface for [BoardGameGeek](https://boardgamegeek.com/).
 
 - 🔥 Browse trending (Hot) games with ratings, weight, and rank
 - 🔍 Search games by name
-- 📚 View user collections with ratings
+- 📚 View user collections with status filter and ratings
 - 📋 Game details: year, rating, geek rating, rank, players, play time, weight, age, owned, comments, designers, artists, categories, mechanics, description
 - 💬 Browse game forums and read threads
 - 🖼️ Thumbnail images via Kitty graphics protocol (currently Ghostty only — see [#10](https://github.com/hiroaqii/bgg-tui/issues/10), [#11](https://github.com/hiroaqii/bgg-tui/issues/11))
@@ -93,7 +93,7 @@ Configuration file is created on first launch in your OS's default config direct
 | `display` | `thread_width` | Forum thread display width |
 | `display` | `detail_width` | Game detail display width |
 | `collection` | `default_username` | Default BGG username for collection lookup |
-| `collection` | `show_only_owned` | Show only owned games in collection |
+| `collection` | `status_filter` | Filter by collection status: owned, prev_owned, for_trade, want, want_to_play, want_to_buy, wishlist, preordered |
 | `api` | `token` | BGG API bearer token |
 
 ## Special Thanks

--- a/go-bgg/collection.go
+++ b/go-bgg/collection.go
@@ -18,8 +18,22 @@ func (c *Client) GetCollection(username string, opts CollectionOptions) ([]Colle
 	}
 
 	endpoint := fmt.Sprintf("/collection?username=%s&stats=1", url.QueryEscape(username))
-	if opts.OwnedOnly {
-		endpoint += "&own=1"
+	for _, f := range []struct {
+		flag bool
+		key  string
+	}{
+		{opts.Own, "own"},
+		{opts.PrevOwned, "prevowned"},
+		{opts.ForTrade, "fortrade"},
+		{opts.Want, "want"},
+		{opts.WantToPlay, "wanttoplay"},
+		{opts.WantToBuy, "wanttobuy"},
+		{opts.Wishlist, "wishlist"},
+		{opts.Preordered, "preordered"},
+	} {
+		if f.flag {
+			endpoint += "&" + f.key + "=1"
+		}
 	}
 
 	body, err := c.doRequestWithRetryOn202(endpoint, collectionMaxRetries)
@@ -58,9 +72,14 @@ func convertXMLToCollectionItem(item xmlCollectionItem) CollectionItem {
 		Thumbnail: item.Thumbnail,
 		Image:     item.Image,
 		NumPlays:  item.NumPlays,
-		Owned:     item.Status.Own == "1",
+		Owned:      item.Status.Own == "1",
+		PrevOwned:  item.Status.PrevOwned == "1",
+		ForTrade:   item.Status.ForTrade == "1",
+		Want:       item.Status.Want == "1",
 		WantToPlay: item.Status.WantToPlay == "1",
-		Wishlist:  item.Status.Wishlist == "1",
+		WantToBuy:  item.Status.WantToBuy == "1",
+		Wishlist:   item.Status.Wishlist == "1",
+		Preordered: item.Status.Preordered == "1",
 	}
 
 	// Parse user rating

--- a/go-bgg/collection_test.go
+++ b/go-bgg/collection_test.go
@@ -65,8 +65,23 @@ func TestGetCollection(t *testing.T) {
 	if !items[0].Owned {
 		t.Error("expected Owned to be true")
 	}
+	if items[0].PrevOwned {
+		t.Error("expected PrevOwned to be false")
+	}
+	if items[0].ForTrade {
+		t.Error("expected ForTrade to be false")
+	}
+	if items[0].Want {
+		t.Error("expected Want to be false")
+	}
 	if !items[0].WantToPlay {
 		t.Error("expected WantToPlay to be true")
+	}
+	if items[0].WantToBuy {
+		t.Error("expected WantToBuy to be false")
+	}
+	if items[0].Preordered {
+		t.Error("expected Preordered to be false")
 	}
 	if items[0].Rating != 8 {
 		t.Errorf("expected Rating 8, got %f", items[0].Rating)
@@ -107,7 +122,7 @@ func TestGetCollection_OwnedOnly(t *testing.T) {
 
 	client := createTestClient(t, server)
 
-	_, err = client.GetCollection("testuser", CollectionOptions{OwnedOnly: true})
+	_, err = client.GetCollection("testuser", CollectionOptions{Own: true})
 	if err != nil {
 		t.Fatalf("GetCollection failed: %v", err)
 	}

--- a/go-bgg/models.go
+++ b/go-bgg/models.go
@@ -68,7 +68,14 @@ type HotGame struct {
 
 // CollectionOptions specifies options for fetching a user's collection.
 type CollectionOptions struct {
-	OwnedOnly bool // true: own=1
+	Own        bool
+	PrevOwned  bool
+	ForTrade   bool
+	Want       bool
+	WantToPlay bool
+	WantToBuy  bool
+	Wishlist   bool
+	Preordered bool
 }
 
 // CollectionItem represents a game in a user's collection.
@@ -84,8 +91,13 @@ type CollectionItem struct {
 	BayesAverage float64 `json:"bayes_average"` // BGG Geek rating (Bayes average)
 	Rank         int     `json:"rank"`          // BGG board game rank (0 = Not Ranked)
 	Owned      bool    `json:"owned"`
+	PrevOwned  bool    `json:"prev_owned"`
+	ForTrade   bool    `json:"for_trade"`
+	Want       bool    `json:"want"`
 	WantToPlay bool    `json:"want_to_play"`
+	WantToBuy  bool    `json:"want_to_buy"`
 	Wishlist   bool    `json:"wishlist"`
+	Preordered bool    `json:"preordered"`
 }
 
 // Forum represents a forum category for a game.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -32,8 +32,9 @@ type DisplayConfig struct {
 
 // CollectionConfig contains collection-related configuration.
 type CollectionConfig struct {
-	DefaultUsername string `toml:"default_username"`
-	ShowOnlyOwned   bool   `toml:"show_only_owned"`
+	DefaultUsername string   `toml:"default_username"`
+	ShowOnlyOwned  bool     `toml:"show_only_owned,omitempty"` // deprecated: migrated to StatusFilter
+	StatusFilter   []string `toml:"status_filter,omitempty"`
 }
 
 // InterfaceConfig contains interface-related configuration.
@@ -61,7 +62,6 @@ func DefaultConfig() *Config {
 		},
 		Collection: CollectionConfig{
 			DefaultUsername: "",
-			ShowOnlyOwned:   false,
 		},
 		Interface: InterfaceConfig{
 			ColorTheme:  "default",
@@ -111,6 +111,13 @@ func LoadFromPath(path string) (*Config, error) {
 			}
 		}
 		return cfg, nil
+	}
+
+	// Migrate deprecated ShowOnlyOwned → StatusFilter
+	if cfg.Collection.ShowOnlyOwned && len(cfg.Collection.StatusFilter) == 0 {
+		cfg.Collection.StatusFilter = []string{"owned"}
+		cfg.Collection.ShowOnlyOwned = false
+		_ = cfg.SaveToPath(path)
 	}
 
 	return cfg, nil

--- a/internal/tui/collection.go
+++ b/internal/tui/collection.go
@@ -212,40 +212,7 @@ func (m collectionModel) Update(msg tea.Msg, client *bgg.Client) (collectionMode
 
 		// Status picker mode
 		if m.statusPicker {
-			switch msg := msg.(type) {
-			case tea.KeyMsg:
-				pickerLen := len(allStatuses) + 1 // +1 for "Show All (clear)"
-				switch {
-				case key.Matches(msg, m.keys.Up):
-					if m.statusCursor > 0 {
-						m.statusCursor--
-					}
-				case key.Matches(msg, m.keys.Down):
-					if m.statusCursor < pickerLen-1 {
-						m.statusCursor++
-					}
-				case key.Matches(msg, m.keys.Enter):
-					if m.statusCursor < len(allStatuses) {
-						// Toggle status
-						s := allStatuses[m.statusCursor]
-						if m.activeStatuses[s] {
-							delete(m.activeStatuses, s)
-						} else {
-							m.activeStatuses[s] = true
-						}
-					} else {
-						// "Show All (clear)"
-						m.activeStatuses = make(map[CollectionStatus]bool)
-					}
-					m.applyStatusFilter()
-					m.saveStatusFilterToConfig()
-					m, cmd := m.maybeLoadThumb()
-					return m, cmd
-				case key.Matches(msg, m.keys.Escape):
-					m.statusPicker = false
-				}
-			}
-			return m, nil
+			return m.updateStatusPicker(msg)
 		}
 
 		if m.filter.active {
@@ -442,6 +409,43 @@ func (m collectionModel) View(width, height int, selType string, animFrame int) 
 	content := b.String()
 	borderStyle := m.config.Interface.BorderStyle
 	return transmit + renderView(content, m.styles, width, height, borderStyle)
+}
+
+// updateStatusPicker handles key input while the status picker is open.
+func (m collectionModel) updateStatusPicker(msg tea.Msg) (collectionModel, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		pickerLen := len(allStatuses) + 1 // +1 for "Show All (clear)"
+		switch {
+		case key.Matches(msg, m.keys.Up):
+			if m.statusCursor > 0 {
+				m.statusCursor--
+			}
+		case key.Matches(msg, m.keys.Down):
+			if m.statusCursor < pickerLen-1 {
+				m.statusCursor++
+			}
+		case key.Matches(msg, m.keys.Enter):
+			if m.statusCursor < len(allStatuses) {
+				// Toggle status
+				s := allStatuses[m.statusCursor]
+				if m.activeStatuses[s] {
+					delete(m.activeStatuses, s)
+				} else {
+					m.activeStatuses[s] = true
+				}
+			} else {
+				// "Show All (clear)"
+				m.activeStatuses = make(map[CollectionStatus]bool)
+			}
+			m.applyStatusFilter()
+			m.saveStatusFilterToConfig()
+			return m.maybeLoadThumb()
+		case key.Matches(msg, m.keys.Escape):
+			m.statusPicker = false
+		}
+	}
+	return m, nil
 }
 
 // renderStatusPicker renders the inline status picker overlay.

--- a/internal/tui/collection.go
+++ b/internal/tui/collection.go
@@ -126,7 +126,7 @@ func (m *collectionModel) applyStatusFilter() {
 
 // renderStatusFilterBar renders all statuses with active ones highlighted and inactive ones muted.
 func (m collectionModel) renderStatusFilterBar() string {
-	activeStyle := lipgloss.NewStyle().Foreground(ColorMuted).Italic(true)
+	activeStyle := lipgloss.NewStyle().Foreground(ColorAccent).Italic(true)
 	dimStyle := lipgloss.NewStyle().Foreground(ColorDim)
 	var parts []string
 	for _, s := range allStatuses {

--- a/internal/tui/collection_status.go
+++ b/internal/tui/collection_status.go
@@ -1,0 +1,110 @@
+package tui
+
+import bgg "github.com/hiroaqii/go-bgg"
+
+// CollectionStatus represents a BGG collection status type.
+type CollectionStatus int
+
+const (
+	StatusOwned CollectionStatus = iota
+	StatusPrevOwned
+	StatusForTrade
+	StatusWant
+	StatusWantToPlay
+	StatusWantToBuy
+	StatusWishlist
+	StatusPreordered
+	statusCount // sentinel
+)
+
+// allStatuses is the ordered list of all statuses shown in the picker.
+var allStatuses = []CollectionStatus{
+	StatusOwned,
+	StatusPrevOwned,
+	StatusForTrade,
+	StatusWant,
+	StatusWantToPlay,
+	StatusWantToBuy,
+	StatusWishlist,
+	StatusPreordered,
+}
+
+// statusLabel returns the display label for a status.
+func statusLabel(s CollectionStatus) string {
+	switch s {
+	case StatusOwned:
+		return "Owned"
+	case StatusPrevOwned:
+		return "Prev Owned"
+	case StatusForTrade:
+		return "For Trade"
+	case StatusWant:
+		return "Want Trade"
+	case StatusWantToPlay:
+		return "Want Play"
+	case StatusWantToBuy:
+		return "Want Buy"
+	case StatusWishlist:
+		return "Wishlist"
+	case StatusPreordered:
+		return "Preordered"
+	}
+	return ""
+}
+
+// statusConfigKey returns the config key used in StatusFilter for a status.
+func statusConfigKey(s CollectionStatus) string {
+	switch s {
+	case StatusOwned:
+		return "owned"
+	case StatusPrevOwned:
+		return "prev_owned"
+	case StatusForTrade:
+		return "for_trade"
+	case StatusWant:
+		return "want"
+	case StatusWantToPlay:
+		return "want_to_play"
+	case StatusWantToBuy:
+		return "want_to_buy"
+	case StatusWishlist:
+		return "wishlist"
+	case StatusPreordered:
+		return "preordered"
+	}
+	return ""
+}
+
+// statusFromConfigKey converts a config key to a CollectionStatus.
+// Returns -1 if not found.
+func statusFromConfigKey(key string) CollectionStatus {
+	for _, s := range allStatuses {
+		if statusConfigKey(s) == key {
+			return s
+		}
+	}
+	return -1
+}
+
+// itemMatchesStatus returns true if the collection item has the given status.
+func itemMatchesStatus(item bgg.CollectionItem, s CollectionStatus) bool {
+	switch s {
+	case StatusOwned:
+		return item.Owned
+	case StatusPrevOwned:
+		return item.PrevOwned
+	case StatusForTrade:
+		return item.ForTrade
+	case StatusWant:
+		return item.Want
+	case StatusWantToPlay:
+		return item.WantToPlay
+	case StatusWantToBuy:
+		return item.WantToBuy
+	case StatusWishlist:
+		return item.Wishlist
+	case StatusPreordered:
+		return item.Preordered
+	}
+	return false
+}

--- a/internal/tui/collection_status.go
+++ b/internal/tui/collection_status.go
@@ -14,8 +14,26 @@ const (
 	StatusWantToBuy
 	StatusWishlist
 	StatusPreordered
-	statusCount // sentinel
 )
+
+// statusDef holds the metadata for a single collection status.
+type statusDef struct {
+	label     string
+	configKey string
+	match     func(bgg.CollectionItem) bool
+}
+
+// statusDefs maps each CollectionStatus to its metadata.
+var statusDefs = [...]statusDef{
+	StatusOwned:      {"Owned", "owned", func(i bgg.CollectionItem) bool { return i.Owned }},
+	StatusPrevOwned:  {"Prev Owned", "prev_owned", func(i bgg.CollectionItem) bool { return i.PrevOwned }},
+	StatusForTrade:   {"For Trade", "for_trade", func(i bgg.CollectionItem) bool { return i.ForTrade }},
+	StatusWant:       {"Want Trade", "want", func(i bgg.CollectionItem) bool { return i.Want }},
+	StatusWantToPlay: {"Want Play", "want_to_play", func(i bgg.CollectionItem) bool { return i.WantToPlay }},
+	StatusWantToBuy:  {"Want Buy", "want_to_buy", func(i bgg.CollectionItem) bool { return i.WantToBuy }},
+	StatusWishlist:   {"Wishlist", "wishlist", func(i bgg.CollectionItem) bool { return i.Wishlist }},
+	StatusPreordered: {"Preordered", "preordered", func(i bgg.CollectionItem) bool { return i.Preordered }},
+}
 
 // allStatuses is the ordered list of all statuses shown in the picker.
 var allStatuses = []CollectionStatus{
@@ -30,56 +48,16 @@ var allStatuses = []CollectionStatus{
 }
 
 // statusLabel returns the display label for a status.
-func statusLabel(s CollectionStatus) string {
-	switch s {
-	case StatusOwned:
-		return "Owned"
-	case StatusPrevOwned:
-		return "Prev Owned"
-	case StatusForTrade:
-		return "For Trade"
-	case StatusWant:
-		return "Want Trade"
-	case StatusWantToPlay:
-		return "Want Play"
-	case StatusWantToBuy:
-		return "Want Buy"
-	case StatusWishlist:
-		return "Wishlist"
-	case StatusPreordered:
-		return "Preordered"
-	}
-	return ""
-}
+func statusLabel(s CollectionStatus) string { return statusDefs[s].label }
 
 // statusConfigKey returns the config key used in StatusFilter for a status.
-func statusConfigKey(s CollectionStatus) string {
-	switch s {
-	case StatusOwned:
-		return "owned"
-	case StatusPrevOwned:
-		return "prev_owned"
-	case StatusForTrade:
-		return "for_trade"
-	case StatusWant:
-		return "want"
-	case StatusWantToPlay:
-		return "want_to_play"
-	case StatusWantToBuy:
-		return "want_to_buy"
-	case StatusWishlist:
-		return "wishlist"
-	case StatusPreordered:
-		return "preordered"
-	}
-	return ""
-}
+func statusConfigKey(s CollectionStatus) string { return statusDefs[s].configKey }
 
 // statusFromConfigKey converts a config key to a CollectionStatus.
 // Returns -1 if not found.
 func statusFromConfigKey(key string) CollectionStatus {
 	for _, s := range allStatuses {
-		if statusConfigKey(s) == key {
+		if statusDefs[s].configKey == key {
 			return s
 		}
 	}
@@ -88,23 +66,5 @@ func statusFromConfigKey(key string) CollectionStatus {
 
 // itemMatchesStatus returns true if the collection item has the given status.
 func itemMatchesStatus(item bgg.CollectionItem, s CollectionStatus) bool {
-	switch s {
-	case StatusOwned:
-		return item.Owned
-	case StatusPrevOwned:
-		return item.PrevOwned
-	case StatusForTrade:
-		return item.ForTrade
-	case StatusWant:
-		return item.Want
-	case StatusWantToPlay:
-		return item.WantToPlay
-	case StatusWantToBuy:
-		return item.WantToBuy
-	case StatusWishlist:
-		return item.Wishlist
-	case StatusPreordered:
-		return item.Preordered
-	}
-	return false
+	return statusDefs[s].match(item)
 }

--- a/internal/tui/hot.go
+++ b/internal/tui/hot.go
@@ -243,7 +243,7 @@ func (m hotModel) View(width, height int, selType string, animFrame int) string 
 
 		displayItems := m.filter.displayItems()
 
-		b.WriteString(m.styles.Subtitle.Render(fmt.Sprintf("%d/%d trending games  ★Rating ⚖Weight #Rank", min(m.filter.cursor+1, len(displayItems)), len(displayItems))))
+		b.WriteString(m.styles.Subtitle.Render(fmt.Sprintf("%d/%d trending games  ★ Rating  ⚖ Weight  #Rank", min(m.filter.cursor+1, len(displayItems)), len(displayItems))))
 		b.WriteString("\n\n")
 
 		if len(displayItems) == 0 {

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -22,7 +22,7 @@ type KeyMap struct {
 	Refresh  key.Binding
 	User     key.Binding
 	Filter   key.Binding
-	Sort     key.Binding
+	StatusFilter key.Binding
 }
 
 // DefaultKeyMap returns the default key bindings.
@@ -100,9 +100,9 @@ func DefaultKeyMap() KeyMap {
 			key.WithKeys("/"),
 			key.WithHelp("/", "filter"),
 		),
-		Sort: key.NewBinding(
+		StatusFilter: key.NewBinding(
 			key.WithKeys("s"),
-			key.WithHelp("s", "sort"),
+			key.WithHelp("s", "status filter"),
 		),
 	}
 }
@@ -118,6 +118,6 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 		{k.Up, k.Down, k.Enter, k.Back},
 		{k.Search, k.Hot, k.Collect, k.Settings},
 		{k.NextPage, k.PrevPage, k.Forum, k.Open},
-		{k.Refresh, k.Filter, k.Sort, k.Help, k.Quit},
+		{k.Refresh, k.Filter, k.StatusFilter, k.Help, k.Quit},
 	}
 }

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -21,7 +21,8 @@ type KeyMap struct {
 	Open     key.Binding
 	Refresh  key.Binding
 	User     key.Binding
-	Filter   key.Binding
+	Filter       key.Binding
+	Sort         key.Binding
 	StatusFilter key.Binding
 }
 
@@ -99,6 +100,10 @@ func DefaultKeyMap() KeyMap {
 		Filter: key.NewBinding(
 			key.WithKeys("/"),
 			key.WithHelp("/", "filter"),
+		),
+		Sort: key.NewBinding(
+			key.WithKeys("s"),
+			key.WithHelp("s", "sort"),
 		),
 		StatusFilter: key.NewBinding(
 			key.WithKeys("s"),

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -203,24 +203,6 @@ func (m *settingsModel) buildItems() []settingItem {
 				return "(not set)"
 			},
 		},
-		{
-			label: "Status Filter", kind: settingInfo,
-			getValue: func() string {
-				if len(cfg.Collection.StatusFilter) == 0 {
-					return "All"
-				}
-				var labels []string
-				for _, key := range cfg.Collection.StatusFilter {
-					if s := statusFromConfigKey(key); s >= 0 {
-						labels = append(labels, statusLabel(s))
-					}
-				}
-				if len(labels) == 0 {
-					return "All"
-				}
-				return strings.Join(labels, ", ")
-			},
-		},
 		// API
 		{
 			label: "Token", section: "API", kind: settingText,

--- a/internal/tui/settings.go
+++ b/internal/tui/settings.go
@@ -204,16 +204,21 @@ func (m *settingsModel) buildItems() []settingItem {
 			},
 		},
 		{
-			label: "Show Only Owned", kind: settingToggle,
+			label: "Status Filter", kind: settingInfo,
 			getValue: func() string {
-				if cfg.Collection.ShowOnlyOwned {
-					return "ON"
+				if len(cfg.Collection.StatusFilter) == 0 {
+					return "All"
 				}
-				return "OFF"
-			},
-			onEnter: func() {
-				cfg.Collection.ShowOnlyOwned = !cfg.Collection.ShowOnlyOwned
-				cfg.Save()
+				var labels []string
+				for _, key := range cfg.Collection.StatusFilter {
+					if s := statusFromConfigKey(key); s >= 0 {
+						labels = append(labels, statusLabel(s))
+					}
+				}
+				if len(labels) == 0 {
+					return "All"
+				}
+				return strings.Join(labels, ", ")
 			},
 		},
 		// API

--- a/internal/tui/settings_test.go
+++ b/internal/tui/settings_test.go
@@ -37,8 +37,8 @@ func TestSettingsItemCount(t *testing.T) {
 	if m.itemCount() != len(m.items) {
 		t.Errorf("itemCount() = %d, len(items) = %d", m.itemCount(), len(m.items))
 	}
-	if m.itemCount() != 14 {
-		t.Errorf("itemCount() = %d, want 14", m.itemCount())
+	if m.itemCount() != 13 {
+		t.Errorf("itemCount() = %d, want 13", m.itemCount())
 	}
 }
 
@@ -91,8 +91,8 @@ func TestSettingsNavigation(t *testing.T) {
 
 	// Can't go below itemCount-1
 	m.cursor = m.itemCount() - 1
-	if m.cursor != 13 {
-		t.Errorf("cursor at last item = %d, want 13", m.cursor)
+	if m.cursor != 12 {
+		t.Errorf("cursor at last item = %d, want 12", m.cursor)
 	}
 }
 

--- a/internal/tui/thread.go
+++ b/internal/tui/thread.go
@@ -131,7 +131,7 @@ func (m threadModel) Update(msg tea.Msg) (threadModel, tea.Cmd) {
 				// Open in browser
 				url := fmt.Sprintf("https://boardgamegeek.com/thread/%d", m.threadID)
 				openBrowser(url)
-			case key.Matches(msg, m.keys.StatusFilter):
+			case key.Matches(msg, m.keys.Sort):
 				m.sortNewest = !m.sortNewest
 				sort.Slice(m.thread.Articles, func(i, j int) bool {
 					ti := parseDate(m.thread.Articles[i].PostDate)

--- a/internal/tui/thread.go
+++ b/internal/tui/thread.go
@@ -131,7 +131,7 @@ func (m threadModel) Update(msg tea.Msg) (threadModel, tea.Cmd) {
 				// Open in browser
 				url := fmt.Sprintf("https://boardgamegeek.com/thread/%d", m.threadID)
 				openBrowser(url)
-			case key.Matches(msg, m.keys.Sort):
+			case key.Matches(msg, m.keys.StatusFilter):
 				m.sortNewest = !m.sortNewest
 				sort.Slice(m.thread.Articles, func(i, j int) bool {
 					ti := parseDate(m.thread.Articles[i].PostDate)


### PR DESCRIPTION
## Summary

- Add a status filter picker (`s` key) to the collection view, allowing users to filter by BGG collection statuses (Owned, Prev Owned, For Trade, Want, Want to Play, Want to Buy, Wishlist, Preordered)
- Replace the old `show_only_owned` toggle with a flexible `status_filter` config option, with automatic migration of existing configs
- Refactor status-related logic into a table-driven design (`collection_status.go`) for maintainability
- Update README with the new feature and configuration documentation

## Test plan

- [x] Launch app, open a collection, press `s` to verify the status picker appears
- [x] Toggle statuses and confirm the list filters correctly
- [x] Close and reopen the app to verify status filter persists in `config.toml`
- [x] Test migration: set `show_only_owned = true` in config, launch app, verify it migrates to `status_filter = ["owned"]`
- [x] Run `go test ./...` to verify all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)